### PR TITLE
Added 'relative' argument to admin_url cal

### DIFF
--- a/author-archive-links.php
+++ b/author-archive-links.php
@@ -143,7 +143,7 @@ class Author_Archive_Links {
 			'autarc-ajax-script',
 			'autarc_obj',
 			array(
-				'ajaxurl'    => admin_url( 'admin-ajax.php' ),
+				'ajaxurl'    => admin_url( 'admin-ajax.php', 'relative' ),
 				'nonce'      => wp_create_nonce( $this->nonce ),
 				'metabox_id' => $this->metabox_id,
 				'metabox_list_id' => $this->metabox_list_id,


### PR DESCRIPTION
because of an edge case where I develop with a localhost dev server (localhost:3000) which provokes a Same Origin error when making ajax calls on the actual wp url (mysite.dev/ ... )